### PR TITLE
Add functionality to update current player turn

### DIFF
--- a/game.js
+++ b/game.js
@@ -17,9 +17,13 @@ class Game {
   }
 
 //A way to keep track of which player's turn it currently is
-  updatePlayerTurns() {
-
+  updateCurrentPlayerTurn() {
+    if (this.playerTurn === 1) {
+      this.playerTurn = 2;
+    } else {
+      this.playerTurn = 1;
   }
+}
 
   //A way to check the Game's board data for win conditions
   checkWinConditions() {

--- a/main.js
+++ b/main.js
@@ -1,0 +1,1 @@
+var ticTacToe = new Game;


### PR DESCRIPTION
Change: Added functionality to update current player after each player has made a move.
Fixed: When the updateCurrentPlayTurn function is called the current player changes from player 1 to player 2.
This is a new feature and it does not break any existing functionality or force to update to a new version.
Tested: With classmates, and with browser dev tools

Future Steps: Add functionality for player to place token