### PR TITLE
Add functionality to clear gameboard after game is won

### DIFF
--- a/game.js
+++ b/game.js
@@ -5,7 +5,7 @@ class Game {
     this.gameboard = ['','','','','','','','',''];
     this.startingPlayer = 1;
     this.currentPlayerTurn = this.startingPlayer;
-    this.currentWinner = [];
+    this.winner = '';
   }
 
   placePlayerToken(position) {
@@ -54,11 +54,11 @@ class Game {
   win() {
     console.log(`${this.currentPlayerTurn} wins!`);
     if (this.currentPlayerTurn === 1) {
-      this.currentWinner = this.player1;
+      this.winner = this.player1;
       this.player1.wins ++;
     }
     if (this.currentPlayerTurn === 2) {
-      this.currentWinner = this.player2;
+      this.winner = this.player2;
       this.player2.wins ++;
     }
     this.resetGameboard();
@@ -68,6 +68,7 @@ class Game {
     if (!this.gameboard.includes('')){
       console.log('draw')
       this.resetGameboard();
+      this.gameReset = true;
     }
   }
 
@@ -77,10 +78,6 @@ class Game {
     this.setStartingPlayer();
   }
 
-  // resetWinner() {
-  //   this.winner = '';
-  // }
-
   setStartingPlayer() {
     if (this.startingPlayer === 1) {
       this.startingPlayer = 2;
@@ -88,4 +85,5 @@ class Game {
       this.startingPlayer = 1;
     }
   }
+
 }

--- a/main.js
+++ b/main.js
@@ -28,15 +28,30 @@ function playerTakeTurn(event) {
   displayWinner();
 }
 
-function displayWinner(){
-  if (ticTacToe.currentWinner === ticTacToe.player1) {
+function displayWinner() {
+  if (ticTacToe.winner === ticTacToe.player1) {
     displayMessage.innerHTML += `
     <h1>Player One WINS!</h1>
     `
+    setTimeout(function() {
+      resetTicTacToe();
+    }, 2000);
   }
-  if (ticTacToe.currentWinner === ticTacToe.player2) {
+  if (ticTacToe.winner === ticTacToe.player2) {
     displayMessage.innerHTML += `
     <h1>Player Two WINS!</h1>
     `
+    setTimeout(function() {
+      resetTicTacToe();
+    }, 2000);
   }
+}
+
+function resetTicTacToe() {
+  var gridPosition = document.querySelectorAll(".box")
+  for (var i = 0; i < gridPosition.length; i++) {
+       gridPosition[i].innerHTML = ``;
+  }
+  ticTacToe.winner = '';
+    displayMessage.innerHTML = ``;
 }


### PR DESCRIPTION
Change: Added functionality to clear the gameboard after game is won
Fixed: No fix.
This is a new feature and it does not break any existing functionality or force to update to a new version.
Tested: With classmates, on the browser, and with browser dev tools

Future Steps: display current turn